### PR TITLE
Add Streamlit chatbot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# ollam
+# Ollama Chatbot Example
+
+This repository contains a small example of using an Ollama model to answer
+questions about a local text file. A simple web interface is provided using
+`streamlit` so you can see results immediately in the browser.
+
+## Requirements
+
+- Python 3.12+
+- An Ollama server running locally with a model installed. You can download a
+  lightweight model with:
+
+  ```bash
+  ollama pull llama3
+  ```
+
+## Running the app
+
+1. Ensure the Ollama server is running (`ollama serve`).
+2. Place the text you want to query in `document.txt`.
+3. Install dependencies:
+
+   ```bash
+   pip install streamlit
+   ```
+
+4. Start the Streamlit app:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+5. A browser window will open automatically. Ask questions in the provided textbox.
+
+## Testing
+
+Run `pytest` to execute the unit tests.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,56 @@
+import json
+import urllib.request
+from pathlib import Path
+
+import streamlit as st
+
+TEXT_FILE = Path("document.txt")
+OLLAMA_URL = "http://localhost:11434/api/chat"
+MODEL = "llama3"
+
+
+def load_context() -> str:
+    """Read the document used as context."""
+    if TEXT_FILE.exists():
+        return TEXT_FILE.read_text(encoding="utf-8")
+    return ""
+
+
+CONTEXT = load_context()
+
+
+def query_model(question: str, context: str, model: str = MODEL) -> str:
+    """Send a chat completion request to the local Ollama server."""
+    data = json.dumps({
+        "model": model,
+        "messages": [
+            {"role": "system", "content": context},
+            {"role": "user", "content": question},
+        ],
+        "stream": False,
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        OLLAMA_URL,
+        data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req) as resp:
+        result = json.loads(resp.read())
+    message = result.get("message", {})
+    return message.get("content", "")
+
+
+def main() -> None:
+    st.title("Ollama Chatbot")
+    with st.form("ask_form"):
+        question = st.text_input("Ask a question")
+        submitted = st.form_submit_button("Ask")
+    if submitted and question:
+        answer = query_model(question, CONTEXT)
+        st.markdown("**Answer:**")
+        st.write(answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/document.txt
+++ b/document.txt
@@ -1,0 +1,1 @@
+This is a local text file used by the Ollama chatbot.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,21 @@
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import app
+
+class QueryModelTest(unittest.TestCase):
+    @patch('urllib.request.urlopen')
+    def test_query_model(self, mock_urlopen):
+        fake_response = MagicMock()
+        fake_response.read.return_value = json.dumps({"message": {"content": "hi"}}).encode('utf-8')
+        mock_urlopen.return_value.__enter__.return_value = fake_response
+
+        result = app.query_model("hello", "context", model="testmodel")
+        self.assertEqual(result, "hi")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert web interface to use Streamlit
- update README instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_686a704205408322ab1f3d94994043d4